### PR TITLE
Replace Respective Image using Custom Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To keep up to date with the latest fixes. See [CHANGELOG.md](https://github.com/
 ## Install
 
 Install via npm:
+
 ```sh
  npm install react-native-images-collage --save
 ```
@@ -34,8 +35,9 @@ Install via npm:
 ## Usage
 
 To use in React Native. Import:
+
 ```js
- import { DynamicCollage, StaticCollage } from 'react-native-images-collage';
+import { DynamicCollage, StaticCollage } from "react-native-images-collage";
 ```
 
 ### Dynamic Collage
@@ -60,21 +62,19 @@ A dynamic collage includes panning, scaling, replacing and image arrangement.
 A static collage does not include any panning, scaling or arrangement logic. Use this if you want to render multiple non-interactive collages. Same props as the dynamic collage.
 
 ```js
-  <StaticCollage
-    width={400}
-    height={400}
-    images={ photos }
-    matrix={ [ 1, 1, 1, 1 ] } />
+<StaticCollage width={400} height={400} images={photos} matrix={[1, 1, 1, 1]} />
 ```
 
 ### Layouts
 
 Instead of building your own matrix of collage layouts. There is a JSON file you can import which includes multiple layouts. Up to 6 images.
+
 ```js
- import { LayoutData } from 'react-native-images-collage';
+import { LayoutData } from "react-native-images-collage";
 ```
 
 You can then access a layout like so:
+
 ```js
  matrix={ LayoutData[NumberOfImages][i].matrix }
  direction={ LayoutData[NumberOfImages][i].direction }
@@ -90,37 +90,38 @@ The number in the first bracket will be the configuration you want to access. E.
 
 ## Props
 
-| Prop                | Type          | Optional  | Default | Description                                                                             |
-| ------------------- | ------------- | --------- | ------- | --------------------------------------------------------------------------------------- |
-| width               | float         | No        |         | Width of component. REQUIRED. Used to calculate image boundaries for switching.         |
-| height              | float         | No        |         | Height of component. REQUIRED. Used to calculate image boundaries for switching.        |
-| images              | array         | No        |         | Images for the collage.                                                                 |
-| matrix              | array         | No        |         | An array [ 1, 1, 1 ] equal to the number of images. Used to define the layout.          |
-| isEditButtonVisible | boolean       | No        |         | A boolean value for the edit button. Used to display the edit button on layout.         |
-| EditButtonComponent | function      | Yes       |         | Custom Edit button component to be displayed on each image in the layout if the value `isEditButtonVisible` will be true.           |
-| editButtonPosition  | enum          | Yes       | top-left| Enum value to set the position of `EditButtonComponent` on each collage image layout.   |
-| onEditButtonPress   | function      | Yes       |         | `EditButtonComponent` when pressed will be triggered to replace the respective image.   |
-| direction           | string        | Yes       | row     | Direction of the collage: 'row' or 'column'.                                            |
-| panningLeftPadding  | number        | Yes       | 15      | Distance image can go beyond the left edge before it is restricted.                     |
-| panningRightPadding | number        | Yes       | 15      | Distance image can go beyond the right edge before it is restricted.                    |
-| panningTopPadding   | number        | Yes       | 15      | Distance image can go beyond the top edge before it is restricted.                      |
-| panningBottomPadding| number        | Yes       | 15      | Distance image can go beyond the bottom edge before it is restricted.                   |
-| scaleAmplifier      | number        | Yes       | 1.0     | Amplifier applied to scaling. Increase this for faster scaling of images.               |
-| retainScaleOnSwap   | boolean       | Yes       | true    | Keep the scale (width/height) of image when it is swapped.                              |
-| longPressDelay      | number        | Yes       | 500     | Delay before long press is activated.                                                   |
-| longPressSensitivity| number        | Yes       | 3       | Sensitivity of the long press, float of 1 (low) to 10+ (high).                                                 |
-| imageStyle          | object        | Yes       | style   | Default image style.                                                                    |
-| imageSelectedStyle  | object        | Yes       | style   | The style applied to the image when it has been selected. Long Pressed.                 |
-| imageSwapStyle      | object        | Yes       | style   | The style applied to the target image which is being swapped. E.g red borders           |
-| imageSwapStyleReset | object        | Yes       | style   | The reverse of imageSwapStyle to reset style after swap. Vital for direct manipulation. |
-| separatorStyle      | object        | Yes       | style   | Style applied to image container. Use border width to create margin between images.     |
-| containerStyle      | object        | Yes       | style   | Style applied to the container of the collage. Collage border can be applied here.      |
+| Prop                 | Type     | Optional | Default  | Description                                                                                                               |
+| -------------------- | -------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| width                | float    | No       |          | Width of component. REQUIRED. Used to calculate image boundaries for switching.                                           |
+| height               | float    | No       |          | Height of component. REQUIRED. Used to calculate image boundaries for switching.                                          |
+| images               | array    | No       |          | Images for the collage.                                                                                                   |
+| matrix               | array    | No       |          | An array [ 1, 1, 1 ] equal to the number of images. Used to define the layout.                                            |
+| isEditButtonVisible  | boolean  | No       |          | A boolean value for the edit button. Used to display the edit button on layout.                                           |
+| EditButtonComponent  | function | Yes      |          | Custom Edit button component to be displayed on each image in the layout if the value `isEditButtonVisible` will be true. |
+| editButtonPosition   | enum     | Yes      | top-left | Enum value to set the position of `EditButtonComponent` on each collage image layout.                                     |
+| editButtonIndent     | number   | Yes      | 20       | Number value to set the indentation of `EditButtonComponent` on each collage image layout.                                |
+| onEditButtonPress    | function | Yes      |          | `EditButtonComponent` when pressed will be triggered to replace the respective image.                                     |
+| direction            | string   | Yes      | row      | Direction of the collage: 'row' or 'column'.                                                                              |
+| panningLeftPadding   | number   | Yes      | 15       | Distance image can go beyond the left edge before it is restricted.                                                       |
+| panningRightPadding  | number   | Yes      | 15       | Distance image can go beyond the right edge before it is restricted.                                                      |
+| panningTopPadding    | number   | Yes      | 15       | Distance image can go beyond the top edge before it is restricted.                                                        |
+| panningBottomPadding | number   | Yes      | 15       | Distance image can go beyond the bottom edge before it is restricted.                                                     |
+| scaleAmplifier       | number   | Yes      | 1.0      | Amplifier applied to scaling. Increase this for faster scaling of images.                                                 |
+| retainScaleOnSwap    | boolean  | Yes      | true     | Keep the scale (width/height) of image when it is swapped.                                                                |
+| longPressDelay       | number   | Yes      | 500      | Delay before long press is activated.                                                                                     |
+| longPressSensitivity | number   | Yes      | 3        | Sensitivity of the long press, float of 1 (low) to 10+ (high).                                                            |
+| imageStyle           | object   | Yes      | style    | Default image style.                                                                                                      |
+| imageSelectedStyle   | object   | Yes      | style    | The style applied to the image when it has been selected. Long Pressed.                                                   |
+| imageSwapStyle       | object   | Yes      | style    | The style applied to the target image which is being swapped. E.g red borders                                             |
+| imageSwapStyleReset  | object   | Yes      | style    | The reverse of imageSwapStyle to reset style after swap. Vital for direct manipulation.                                   |
+| separatorStyle       | object   | Yes      | style    | Style applied to image container. Use border width to create margin between images.                                       |
+| containerStyle       | object   | Yes      | style    | Style applied to the container of the collage. Collage border can be applied here.                                        |
 
 ## Showcase
 
- - Qeepsake - The Text Message Baby Journal on [iOS](https://itunes.apple.com/us/app/qeepsake/id1332312787?mt=8) and [Android](https://play.google.com/store/apps/details?id=co.qeepsake.qeepsakeApp&hl=en_GB).
- 
- If you use the collage in your application then create a pull request to feature it here.
+- Qeepsake - The Text Message Baby Journal on [iOS](https://itunes.apple.com/us/app/qeepsake/id1332312787?mt=8) and [Android](https://play.google.com/store/apps/details?id=co.qeepsake.qeepsakeApp&hl=en_GB).
+
+If you use the collage in your application then create a pull request to feature it here.
 
 ## License
 
@@ -142,6 +143,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ A dynamic collage includes panning, scaling, replacing and image arrangement.
     isEditButtonVisible: { true | false },
     EditButtonComponent: { ( <YourCustomComponent/> ) }
     editButtonPosition: { 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' },
-    onEditButtonPress: { (m, i) => { collageRef.replace( 'NewImage' , m , i ) } }
+    onEditButtonPress: { (m, i) => { collageRef.current.replaceImage( 'NewImage' , m , i ) } }
     />
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,19 @@ To use in React Native. Import:
 
 ### Dynamic Collage
 
-A dynamic collage includes panning, scaling and image arrangement.
+A dynamic collage includes panning, scaling, replacing and image arrangement.
 
 ```js
   <DynamicCollage
     width={400}
     height={400}
     images={ photos }
-    matrix={ [ 1, 1, 1, 1 ] } />
+    matrix={ [ 1, 1, 1, 1 ] }
+    isEditButtonVisible: { true | false },
+    EditButtonComponent: { ( <YourCustomComponent/> ) }
+    editButtonPosition: { 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' },
+    onEditButtonPress: { (m, i) => { collageRef.replace( 'NewImage' , m , i ) } }
+    />
 ```
 
 ### Static Collage
@@ -91,6 +96,10 @@ The number in the first bracket will be the configuration you want to access. E.
 | height              | float         | No        |         | Height of component. REQUIRED. Used to calculate image boundaries for switching.        |
 | images              | array         | No        |         | Images for the collage.                                                                 |
 | matrix              | array         | No        |         | An array [ 1, 1, 1 ] equal to the number of images. Used to define the layout.          |
+| isEditButtonVisible | boolean       | No        |         | A boolean value for the edit button. Used to display the edit button on layout.         |
+| EditButtonComponent | function      | Yes       |         | Custom Edit button component to be displayed on each image in the layout if the value `isEditButtonVisible` will be true.           |
+| editButtonPosition  | enum          | Yes       | top-left| Enum value to set the position of `EditButtonComponent` on each collage image layout.   |
+| onEditButtonPress   | function      | Yes       |         | `EditButtonComponent` when pressed will be triggered to replace the respective image.   |
 | direction           | string        | Yes       | row     | Direction of the collage: 'row' or 'column'.                                            |
 | panningLeftPadding  | number        | Yes       | 15      | Distance image can go beyond the left edge before it is restricted.                     |
 | panningRightPadding | number        | Yes       | 15      | Distance image can go beyond the right edge before it is restricted.                    |

--- a/src/CollageImage.js
+++ b/src/CollageImage.js
@@ -583,7 +583,9 @@ class CollageImage extends React.Component {
             onPress={this.props.onEditButtonPress}
             style={{
               position: "absolute",
-              margin: 20,
+              margin: this.props.editButtonIndent
+                ? this.props.editButtonIndent
+                : 20,
               top: this.props.editButtonPosition.includes("top") ? 0 : null,
               bottom: this.props.editButtonPosition.includes("bottom")
                 ? 0
@@ -613,6 +615,7 @@ CollageImage.propTypes = {
   EditButtonComponent: PropTypes.func,
   editButtonPosition: PropTypes.string,
   isEditButtonVisible: PropTypes.bool,
+  editButtonIndent: PropTypes.number,
 };
 
 export default CollageImage;

--- a/src/CollageImage.js
+++ b/src/CollageImage.js
@@ -1,6 +1,14 @@
-import React from 'react';
-import { View, Image, PanResponder, StyleSheet, Animated, TouchableWithoutFeedback } from 'react-native';
-import PropTypes from 'prop-types';
+import React from "react";
+import {
+  View,
+  Image,
+  PanResponder,
+  StyleSheet,
+  Animated,
+  TouchableWithoutFeedback,
+  TouchableOpacity,
+} from "react-native";
+import PropTypes from "prop-types";
 
 class CollageImage extends React.Component {
   constructor(props) {
@@ -12,7 +20,7 @@ class CollageImage extends React.Component {
       selected: false,
       animating: false,
       panningX: 0,
-      panningY:  0,
+      panningY: 0,
       translateX: 0,
       translateY: 0,
       width: 0,
@@ -75,17 +83,32 @@ class CollageImage extends React.Component {
         }, props.longPressDelay);
       },
       onPanResponderMove: (evt, gestureState) => {
-        const { panningX, panningY, width, height, initialWidth, initialHeight, ratio } = this.state;
+        const {
+          panningX,
+          panningY,
+          width,
+          height,
+          initialWidth,
+          initialHeight,
+          ratio,
+        } = this.state;
         const { scaleAmplifier, longPressSensitivity } = this.props;
-        const { relativeContainerWidth, relativeContainerHeight } = this.props.boundaries;
+        const {
+          relativeContainerWidth,
+          relativeContainerHeight,
+        } = this.props.boundaries;
 
         const moveX = gestureState.moveX; // MOVEMENT ALONG THE X
         const moveY = gestureState.moveY; // MOVEMENT ALONG THE Y
 
         //INTERRUPT ANIMATIONS
-        if(this.snapAnimation != null){
+        if (this.snapAnimation != null) {
           // CANCEL ANIMARION AND CAPTURE POSITION
-          this.setState({ animating: false, panningX: this.animatedX._value, panningY: this.animatedY._value });
+          this.setState({
+            animating: false,
+            panningX: this.animatedX._value,
+            panningY: this.animatedY._value,
+          });
 
           // INTERRUPT ANIMATION
           this.snapAnimation.stop();
@@ -93,9 +116,9 @@ class CollageImage extends React.Component {
         }
 
         // PAN
-        if(gestureState.numberActiveTouches == 1){
-          if(!this.state.animating){
-            if(!this.panning){
+        if (gestureState.numberActiveTouches == 1) {
+          if (!this.state.animating) {
+            if (!this.panning) {
               this.panning = true;
 
               this.originPanningX = moveX;
@@ -110,33 +133,44 @@ class CollageImage extends React.Component {
             } else {
               // CALCULATE MOVEMENT
 
-              if(!this.state.selected){
+              if (!this.state.selected) {
                 // IMAGE IS NOT SELECTED - CALCULATE PANNING
 
                 // CALCULATE FRICTION TO APPLY TO PANNING (APPLIED WHEN IMAGE REACHES END OF BOUND FOR RESISTANCE EFFECT)
-                const { frictionX, frictionY } = this.calculateFriction(panningX, panningY);
+                const { frictionX, frictionY } = this.calculateFriction(
+                  panningX,
+                  panningY
+                );
 
                 const panningMovementX = this.originPanningX - moveX;
                 const panningMovementY = this.originPanningY - moveY;
 
                 // CALCULATE THE DIRECTION WE ARE PANNING IN
-                this.directionX = (this.deltaPanningX - panningMovementX) > 0 ? 'right' : 'left';
-                this.directionY = (this.deltaPanningY - panningMovementY) > 0 ? 'down' : 'up';
+                this.directionX =
+                  this.deltaPanningX - panningMovementX > 0 ? "right" : "left";
+                this.directionY =
+                  this.deltaPanningY - panningMovementY > 0 ? "down" : "up";
 
                 // CALCULATE THE INCREMENTS BETWEEN PANNING IN ORDER TO APPLY FRICTION FORCE
-                const incrementX = (this.deltaPanningX - panningMovementX) * frictionX;
-                const incrementY = (this.deltaPanningY - panningMovementY) * frictionY;
+                const incrementX =
+                  (this.deltaPanningX - panningMovementX) * frictionX;
+                const incrementY =
+                  (this.deltaPanningY - panningMovementY) * frictionY;
 
                 // APPLY THE INCREMENT TO OUR PANNING VALUE
-                const newPanningX = (panningX - incrementX);
-                const newPanningY = (panningY - incrementY);
+                const newPanningX = panningX - incrementX;
+                const newPanningY = panningY - incrementY;
 
                 // How much movement should cancel the long press? We use a base of 10.
                 const longPressCancelSensitivity = 10 * longPressSensitivity;
 
                 // Clear long press timer if we are panning
-                if(Math.abs(panningMovementX) > longPressCancelSensitivity || Math.abs(panningMovementY) > longPressCancelSensitivity)
-                  if (this.onLongPressTimeout) clearTimeout(this.onLongPressTimeout);
+                if (
+                  Math.abs(panningMovementX) > longPressCancelSensitivity ||
+                  Math.abs(panningMovementY) > longPressCancelSensitivity
+                )
+                  if (this.onLongPressTimeout)
+                    clearTimeout(this.onLongPressTimeout);
 
                 this.setState({ panningX: newPanningX, panningY: newPanningY });
 
@@ -156,55 +190,81 @@ class CollageImage extends React.Component {
             }
           }
           // SCALE
-        } else if(gestureState.numberActiveTouches == 2) {
-          const touches = evt.touchHistory.touchBank.filter(item => item !== null || item !== undefined);
+        } else if (gestureState.numberActiveTouches == 2) {
+          const touches = evt.touchHistory.touchBank.filter(
+            (item) => item !== null || item !== undefined
+          );
           const touchOne = touches[0];
           const touchTwo = touches[1];
 
           const scalingValue = Math.max(
-              Math.abs(touchOne.currentPageX - touchTwo.currentPageX),
-              Math.abs(touchOne.currentPageY - touchTwo.currentPageY)
+            Math.abs(touchOne.currentPageX - touchTwo.currentPageX),
+            Math.abs(touchOne.currentPageY - touchTwo.currentPageY)
           ); // SCALING AMOUNT
 
           // Clear long press timer if we are scaling
           if (this.onLongPressTimeout) clearTimeout(this.onLongPressTimeout);
 
-          if(!this.scaling){
+          if (!this.scaling) {
             // FIRST TOUCH - START SCALING
             this.scaling = true;
 
             this.deltaScaling = scalingValue;
           } else {
             // SCALING
-            const incrementScaling = (this.deltaScaling - scalingValue) * scaleAmplifier;
+            const incrementScaling =
+              (this.deltaScaling - scalingValue) * scaleAmplifier;
 
             // Support portrait and landscape photos by scaling each axis by ratio depending on the image properties
-            const incrementScalingWidth = initialWidth > initialHeight ? incrementScaling * ratio : incrementScaling;
-            const incrementScalingHeight = initialHeight > initialWidth ? incrementScaling * ratio : incrementScaling;
+            const incrementScalingWidth =
+              initialWidth > initialHeight
+                ? incrementScaling * ratio
+                : incrementScaling;
+            const incrementScalingHeight =
+              initialHeight > initialWidth
+                ? incrementScaling * ratio
+                : incrementScaling;
 
             // Calculate our new image size from scaling
             const newWidth = width - incrementScalingWidth;
             const newHeight = height - incrementScalingHeight;
 
             // Don't scale if width or height is not greater than container, we always scale if the scale is positive (making the image larger)
-            if(newWidth > relativeContainerWidth && height > relativeContainerHeight || incrementScaling < 0) {
+            if (
+              (newWidth > relativeContainerWidth &&
+                height > relativeContainerHeight) ||
+              incrementScaling < 0
+            ) {
               // Calculate anchor pecentage, where has the user started the scale relative to the container as a percentage
-              const anchorRelativePercentageX = ((moveX - this.props.collageOffsetX) / relativeContainerWidth) * 100;
-              const anchorRelativePercentageY = ((moveY - this.props.collageOffsetY) / relativeContainerHeight) * 100;
+              const anchorRelativePercentageX =
+                ((moveX - this.props.collageOffsetX) / relativeContainerWidth) *
+                100;
+              const anchorRelativePercentageY =
+                ((moveY - this.props.collageOffsetY) /
+                  relativeContainerHeight) *
+                100;
 
               // Calculate anchor point relative to image width
-              const anchorPointX = Math.max(1, 3 * anchorRelativePercentageX / 100);
-              const anchorPointY = Math.max(1, 3 * anchorRelativePercentageY / 100);
+              const anchorPointX = Math.max(
+                1,
+                (3 * anchorRelativePercentageX) / 100
+              );
+              const anchorPointY = Math.max(
+                1,
+                (3 * anchorRelativePercentageY) / 100
+              );
 
               // Calculate anchor panning to scale by center
-              const anchorPanningX = panningX - (width - newWidth) / anchorPointX;
-              const anchorPanningY = panningY - (height - newHeight) / anchorPointY;
+              const anchorPanningX =
+                panningX - (width - newWidth) / anchorPointX;
+              const anchorPanningY =
+                panningY - (height - newHeight) / anchorPointY;
 
               this.setState({
                 width: newWidth,
                 height: newHeight,
                 panningX: anchorPanningX,
-                panningY: anchorPanningY
+                panningY: anchorPanningY,
               });
             }
 
@@ -219,9 +279,9 @@ class CollageImage extends React.Component {
         this.scaling = false;
 
         // Clear long press timer
-        if(this.onLongPressTimeout) clearTimeout(this.onLongPressTimeout);
+        if (this.onLongPressTimeout) clearTimeout(this.onLongPressTimeout);
 
-        if(this.state.selected){
+        if (this.state.selected) {
           this.props.translationEndCallback(this);
           this.setState({ selected: false, translateX: 0, translateY: 0 });
         }
@@ -233,8 +293,16 @@ class CollageImage extends React.Component {
     this.calculateImageSize();
   }
 
-  componentDidUpdate(prevProps){
-    const { matrix, direction, boundaries, panningLeftPadding, panningRightPadding, panningTopPadding, panningBottomPadding } = this.props;
+  componentDidUpdate(prevProps) {
+    const {
+      matrix,
+      direction,
+      boundaries,
+      panningLeftPadding,
+      panningRightPadding,
+      panningTopPadding,
+      panningBottomPadding,
+    } = this.props;
     const { width, height } = this.state;
 
     this.leftEdge = 0;
@@ -248,8 +316,8 @@ class CollageImage extends React.Component {
     this.bottomEdgeMax = this.bottomEdge + panningBottomPadding;
 
     // Auto resize collage images when Matrix, or direction is updated.
-    if(matrix !== prevProps.matrix || direction !== prevProps.direction){
-      if(this.snapAnimation != null) {
+    if (matrix !== prevProps.matrix || direction !== prevProps.direction) {
+      if (this.snapAnimation != null) {
         // INTERRUPT ANIMATION
         this.snapAnimation.stop();
         this.snapAnimation = null;
@@ -257,36 +325,52 @@ class CollageImage extends React.Component {
 
       this.setState({
         panningX: 0,
-        panningY: 0
+        panningY: 0,
       });
 
       this.calculateImageSize();
     }
   }
 
-  componentWillUnmount(){
+  componentWillUnmount() {
     // Clear long press timer when component is unmounted
     if (this.onLongPressTimeout) clearTimeout(this.onLongPressTimeout);
   }
 
-  calculateFriction(x, y){
+  calculateFriction(x, y) {
     let frictionX = 1.0;
     let frictionY = 1.0;
 
-    if(x < this.leftEdge && this.directionX === 'right'){ // TOO FAR RIGHT
-      frictionX = Math.max(0, (x - this.leftEdgeMax) / (this.leftEdge - this.leftEdgeMax)); // REVERSE NORMALIZATION
+    if (x < this.leftEdge && this.directionX === "right") {
+      // TOO FAR RIGHT
+      frictionX = Math.max(
+        0,
+        (x - this.leftEdgeMax) / (this.leftEdge - this.leftEdgeMax)
+      ); // REVERSE NORMALIZATION
     }
 
-    if(x > this.rightEdge && this.directionX === 'left'){ // TOO FAR RIGHT
-      frictionX = Math.max(0, (x - this.rightEdgeMax) / (this.rightEdge - this.rightEdgeMax)); // REVERSE NORMALIZATION
+    if (x > this.rightEdge && this.directionX === "left") {
+      // TOO FAR RIGHT
+      frictionX = Math.max(
+        0,
+        (x - this.rightEdgeMax) / (this.rightEdge - this.rightEdgeMax)
+      ); // REVERSE NORMALIZATION
     }
 
-    if(y < this.topEdge && this.directionY === 'down'){ // TOO FAR DOWN
-      frictionY = Math.max(0, (y - this.topEdgeMax) / (this.topEdge - this.topEdgeMax)); // REVERSE NORMALIZATION
+    if (y < this.topEdge && this.directionY === "down") {
+      // TOO FAR DOWN
+      frictionY = Math.max(
+        0,
+        (y - this.topEdgeMax) / (this.topEdge - this.topEdgeMax)
+      ); // REVERSE NORMALIZATION
     }
 
-    if(y > this.bottomEdge && this.directionY === 'up'){ // TOO FAR UP
-      frictionY = Math.max(0, (y - this.bottomEdgeMax) / (this.bottomEdge - this.bottomEdgeMax)); // REVERSE NORMALIZATION
+    if (y > this.bottomEdge && this.directionY === "up") {
+      // TOO FAR UP
+      frictionY = Math.max(
+        0,
+        (y - this.bottomEdgeMax) / (this.bottomEdge - this.bottomEdgeMax)
+      ); // REVERSE NORMALIZATION
     }
 
     return { frictionX, frictionY };
@@ -295,7 +379,7 @@ class CollageImage extends React.Component {
   /**
    * Updates the image postion, will use animation to snap the image into place if it is out of bounds
    */
-  calculateImagePosition(){
+  calculateImagePosition() {
     const { panningX, panningY } = this.state;
 
     this.setState({ animating: true });
@@ -305,21 +389,32 @@ class CollageImage extends React.Component {
 
     let animateXTo = this.animatedX._value;
     let animateYTo = this.animatedY._value;
-    if(panningX < this.leftEdge){ animateXTo = this.leftEdge; }
-    if(panningX > this.rightEdge){ animateXTo = this.rightEdge; }
-    if(panningY < this.topEdge){ animateYTo = this.topEdge; }
-    if(panningY > this.bottomEdge){ animateYTo = this.bottomEdge; }
+    if (panningX < this.leftEdge) {
+      animateXTo = this.leftEdge;
+    }
+    if (panningX > this.rightEdge) {
+      animateXTo = this.rightEdge;
+    }
+    if (panningY < this.topEdge) {
+      animateYTo = this.topEdge;
+    }
+    if (panningY > this.bottomEdge) {
+      animateYTo = this.bottomEdge;
+    }
 
-    if(animateXTo != this.animatedX._value || animateYTo != this.animatedY._value){
+    if (
+      animateXTo != this.animatedX._value ||
+      animateYTo != this.animatedY._value
+    ) {
       this.snapAnimation = Animated.parallel([
         Animated.spring(this.animatedX, {
           toValue: animateXTo,
-          duration: 100
+          duration: 100,
         }),
         Animated.spring(this.animatedY, {
           toValue: animateYTo,
-          duration: 100
-        })
+          duration: 100,
+        }),
       ]);
 
       this.snapAnimation.start(() => {
@@ -337,28 +432,35 @@ class CollageImage extends React.Component {
    * @param targetHeight {number} target height to overwite the height to be calculated
    * @param keepScale {bool} Keeps the scale of the image, does not try to adjust to container size
    */
-  calculateImageSize(targetWidth = null, targetHeight = null, keepScale = false){
+  calculateImageSize(
+    targetWidth = null,
+    targetHeight = null,
+    keepScale = false
+  ) {
     Image.getSize(this.props.source.uri, (width, height) => {
       // SCALE IMAGE TO FIT THE CONTAINER
       const { imageWidth, imageHeight } = this.calculateAspectRatioFit(
-          targetWidth ? targetWidth : width,
-          targetHeight ? targetHeight : height,
-          this.props.boundaries.relativeContainerWidth,
-          this.props.boundaries.relativeContainerHeight,
-          keepScale
+        targetWidth ? targetWidth : width,
+        targetHeight ? targetHeight : height,
+        this.props.boundaries.relativeContainerWidth,
+        this.props.boundaries.relativeContainerHeight,
+        keepScale
       );
 
-      this.setState({
-        width: imageWidth,
-        height: imageHeight,
-        initialWidth: imageWidth,
-        initialHeight: imageHeight,
-        srcWidth: width,
-        srcHeight: height,
-        ratio: Math.max(imageHeight / imageWidth, imageWidth / imageHeight)
-      }, () => {
-        this.calculateImagePosition();
-      });
+      this.setState(
+        {
+          width: imageWidth,
+          height: imageHeight,
+          initialWidth: imageWidth,
+          initialHeight: imageHeight,
+          srcWidth: width,
+          srcHeight: height,
+          ratio: Math.max(imageHeight / imageWidth, imageWidth / imageHeight),
+        },
+        () => {
+          this.calculateImagePosition();
+        }
+      );
     });
   }
 
@@ -375,12 +477,18 @@ class CollageImage extends React.Component {
    *
    * @return {Object} { imageWidth, imageHeight }
    */
-  calculateAspectRatioFit(srcWidth, srcHeight, maxWidth, maxHeight, keepScale = false) {
+  calculateAspectRatioFit(
+    srcWidth,
+    srcHeight,
+    maxWidth,
+    maxHeight,
+    keepScale = false
+  ) {
     const newMaxWidth = keepScale ? Math.max(srcWidth, maxWidth) : maxWidth;
     const newMaxHeight = keepScale ? Math.max(srcHeight, maxHeight) : maxHeight;
 
     const ratio = Math.max(newMaxWidth / srcWidth, newMaxHeight / srcHeight);
-    return { imageWidth: srcWidth*ratio, imageHeight: srcHeight*ratio };
+    return { imageWidth: srcWidth * ratio, imageHeight: srcHeight * ratio };
   }
 
   /**
@@ -388,7 +496,7 @@ class CollageImage extends React.Component {
    *
    * @param image - A CollageImage class
    */
-  imageSwapped(image){
+  imageSwapped(image) {
     const { retainScaleOnSwap } = this.props;
 
     // SWAP PROPERTIES
@@ -397,46 +505,97 @@ class CollageImage extends React.Component {
     const targetImageWidth = image.state.width;
     const targetImageHeight = image.state.height;
 
-    if(targetImagePanningX < this.leftEdge){ targetImagePanningX = this.leftEdge; }
-    if(targetImagePanningX > this.rightEdge){ targetImagePanningX = this.rightEdge; }
-    if(targetImagePanningY < this.topEdge){ targetImagePanningY = this.topEdge; }
-    if(targetImagePanningY > this.bottomEdge){ targetImagePanningY = this.bottomEdge; }
+    if (targetImagePanningX < this.leftEdge) {
+      targetImagePanningX = this.leftEdge;
+    }
+    if (targetImagePanningX > this.rightEdge) {
+      targetImagePanningX = this.rightEdge;
+    }
+    if (targetImagePanningY < this.topEdge) {
+      targetImagePanningY = this.topEdge;
+    }
+    if (targetImagePanningY > this.bottomEdge) {
+      targetImagePanningY = this.bottomEdge;
+    }
 
     // WHEN IMAGE IS SWAPPED THEN WE RECALCULATE THE SIZE.
-    this.calculateImageSize(targetImageWidth, targetImageHeight, retainScaleOnSwap);
+    this.calculateImageSize(
+      targetImageWidth,
+      targetImageHeight,
+      retainScaleOnSwap
+    );
 
     this.setState({
       panningX: targetImagePanningX,
-      panningY: targetImagePanningY
+      panningY: targetImagePanningY,
     });
   }
 
   render() {
     const { source, style, imageSelectedStyle } = this.props;
-    const { panningX, panningY, translateX, translateY, width, height, selected, animating } = this.state;
+    const {
+      panningX,
+      panningY,
+      translateX,
+      translateY,
+      width,
+      height,
+      selected,
+      animating,
+    } = this.state;
 
     const right = animating ? this.animatedX : panningX;
     const bottom = animating ? this.animatedY : panningY;
 
     return (
+      <View
+        ref={"imageContainer"}
+        style={{
+          flex: 1,
+          overflow: "hidden",
+          transform: [{ translateX: -translateX }, { translateY: -translateY }],
+          borderWidth: 2,
+          borderColor: "white",
+        }}
+      >
         <View
-            ref={'imageContainer'}
-            style={{
-              flex: 1, overflow: 'hidden',
-              transform: [
-                { translateX: -translateX },
-                { translateY: -translateY },
-              ],
-              borderWidth: 2, borderColor: 'white'
-            }}>
-          <View style={{ flex: 1, flexDirection: 'row', width: width, height: height }} {...this._panResponder.panHandlers}>
-            <Animated.Image
-                ref={'image'}
-                source={source}
-                style={[ style, { right, bottom, width, height }, selected ? imageSelectedStyle : null]}
-                resizeMode='cover' />
-          </View>
+          style={{
+            flex: 1,
+            flexDirection: "row",
+            width: width,
+            height: height,
+          }}
+          {...this._panResponder.panHandlers}
+        >
+          <Animated.Image
+            ref={"image"}
+            source={source}
+            style={[
+              style,
+              { right, bottom, width, height },
+              selected ? imageSelectedStyle : null,
+            ]}
+            resizeMode="cover"
+          />
         </View>
+        {this.props.isEditButtonVisible && (
+          <TouchableOpacity
+            onPress={this.props.onEditButtonPress}
+            style={{
+              position: "absolute",
+              margin: 20,
+              top: this.props.editButtonPosition.includes("top") ? 0 : null,
+              bottom: this.props.editButtonPosition.includes("bottom")
+                ? 0
+                : null,
+              left: this.props.editButtonPosition.includes("left") ? 0 : null,
+              right: this.props.editButtonPosition.includes("right") ? 0 : null,
+            }}
+          >
+            {this.props.EditButtonComponent()}
+          </TouchableOpacity>
+        )}
+      </View>
     );
   }
 }
@@ -450,6 +609,10 @@ CollageImage.propTypes = {
   retainScaleOnSwap: PropTypes.bool,
   longPressDelay: PropTypes.number,
   longPressSensitivity: PropTypes.number, // 1 - 20 - How sensitive is the long press?
+  onEditButtonPress: PropTypes.func,
+  EditButtonComponent: PropTypes.func,
+  editButtonPosition: PropTypes.string,
+  isEditButtonVisible: PropTypes.bool,
 };
 
 export default CollageImage;

--- a/src/CollageImage.js
+++ b/src/CollageImage.js
@@ -586,12 +586,26 @@ class CollageImage extends React.Component {
               margin: this.props.editButtonIndent
                 ? this.props.editButtonIndent
                 : 20,
-              top: this.props.editButtonPosition.includes("top") ? 0 : null,
-              bottom: this.props.editButtonPosition.includes("bottom")
-                ? 0
-                : null,
-              left: this.props.editButtonPosition.includes("left") ? 0 : null,
-              right: this.props.editButtonPosition.includes("right") ? 0 : null,
+              top:
+                this.props.editButtonPosition &&
+                this.props.editButtonPosition.includes("top")
+                  ? 0
+                  : null,
+              bottom:
+                this.props.editButtonPosition &&
+                this.props.editButtonPosition.includes("bottom")
+                  ? 0
+                  : null,
+              left:
+                this.props.editButtonPosition &&
+                this.props.editButtonPosition.includes("left")
+                  ? 0
+                  : null,
+              right:
+                this.props.editButtonPosition &&
+                this.props.editButtonPosition.includes("right")
+                  ? 0
+                  : null,
             }}
           >
             {this.props.EditButtonComponent()}
@@ -613,7 +627,12 @@ CollageImage.propTypes = {
   longPressSensitivity: PropTypes.number, // 1 - 20 - How sensitive is the long press?
   onEditButtonPress: PropTypes.func,
   EditButtonComponent: PropTypes.func,
-  editButtonPosition: PropTypes.string,
+  editButtonPosition: PropTypes.oneOf([
+    "top-left",
+    "top-right",
+    "bottom-left",
+    "bottom-right",
+  ]),
   isEditButtonVisible: PropTypes.bool,
   editButtonIndent: PropTypes.number,
 };

--- a/src/DynamicCollage.js
+++ b/src/DynamicCollage.js
@@ -65,6 +65,7 @@ class DynamicCollage extends React.Component {
               isEditButtonVisible={this.props.isEditButtonVisible}
               EditButtonComponent={this.props.EditButtonComponent}
               editButtonPosition={this.props.editButtonPosition}
+              editButtonIndent={this.props.editButtonIndent}
               matrix={matrix}
               direction={direction}
               longPressSensitivity={longPressSensitivity}
@@ -347,6 +348,7 @@ DynamicCollage.propTypes = {
   EditButtonComponent: PropTypes.func,
   editButtonPosition: PropTypes.string,
   isEditButtonVisible: PropTypes.bool,
+  editButtonIndent: PropTypes.number,
 };
 
 export { DynamicCollage };

--- a/src/DynamicCollage.js
+++ b/src/DynamicCollage.js
@@ -346,7 +346,12 @@ DynamicCollage.propTypes = {
   longPressSensitivity: PropTypes.number, // 1 - 20 - How sensitive is the long press?
   onEditButtonPress: PropTypes.func,
   EditButtonComponent: PropTypes.func,
-  editButtonPosition: PropTypes.string,
+  editButtonPosition: PropTypes.oneOf([
+    "top-left",
+    "top-right",
+    "bottom-left",
+    "bottom-right",
+  ]),
   isEditButtonVisible: PropTypes.bool,
   editButtonIndent: PropTypes.number,
 };

--- a/src/DynamicCollage.js
+++ b/src/DynamicCollage.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import { View, Image, StyleSheet } from 'react-native';
-import PropTypes from 'prop-types';
+import React from "react";
+import { View, Image, StyleSheet } from "react-native";
+import PropTypes from "prop-types";
 
-import CollageImage from './CollageImage';
+import CollageImage from "./CollageImage";
 
 class DynamicCollage extends React.Component {
   constructor(props) {
@@ -17,56 +17,71 @@ class DynamicCollage extends React.Component {
     };
   }
 
-  renderMatrix(){
-    const { matrix, direction, retainScaleOnSwap, longPressDelay, longPressSensitivity } = this.props;
+  renderMatrix() {
+    const {
+      matrix,
+      direction,
+      retainScaleOnSwap,
+      longPressDelay,
+      longPressSensitivity,
+    } = this.props;
     const { collageOffsetX, collageOffsetY } = this.state;
 
-    const sectionDirection = (direction === 'row') ? 'column' : 'row';
+    const sectionDirection = direction === "row" ? "column" : "row";
     const reducer = (accumulator, currentValue) => accumulator + currentValue;
 
     return matrix.map((element, m, array) => {
       const startIndex = m ? array.slice(0, m).reduce(reducer) : 0;
 
-      const images = this.state.images.slice(startIndex, startIndex + element).map((image, i) => {
-        // Determines if the source is a URL, or local asset
-        const source = Number.isInteger(image) ? Image.resolveAssetSource(image) : { uri: image };
+      const images = this.state.images
+        .slice(startIndex, startIndex + element)
+        .map((image, i) => {
+          // Determines if the source is a URL, or local asset
+          const source = Number.isInteger(image)
+            ? Image.resolveAssetSource(image)
+            : { uri: image };
 
-        return (
+          return (
             <CollageImage
-                key={i}
-                ref={`image${m}-${i}`}
-                source={source}
-                style={[ { flex: 1 }, this.props.imageStyle ]}
-                boundaries={ this.getImageBoundaries(m, i) }
-                translationStartCallback={ this.imageTranslationStart.bind(this) }
-                translationUpdateCallback={ this.imageTranslationUpdate.bind(this) }
-                translationEndCallback={ this.imageTranslationEnd.bind(this) }
-                matrixId={m}
-                imageId={`image${m}-${i}`}
-                imageSelectedStyle={ this.props.imageSelectedStyle }
-                panningLeftPadding={this.props.panningLeftPadding}
-                panningRightPadding={this.props.panningRightPadding}
-                panningTopPadding={this.props.panningTopPadding}
-                panningBottomPadding={this.props.panningBottomPadding}
-                scaleAmplifier={this.props.scaleAmplifier}
-                retainScaleOnSwap={retainScaleOnSwap}
-                longPressDelay={longPressDelay}
-                matrix={matrix}
-                direction={direction}
-                longPressSensitivity={longPressSensitivity}
-                collageOffsetX={collageOffsetX}
-                collageOffsetY={collageOffsetY}
+              key={i}
+              ref={`image${m}-${i}`}
+              source={source}
+              style={[{ flex: 1 }, this.props.imageStyle]}
+              boundaries={this.getImageBoundaries(m, i)}
+              translationStartCallback={this.imageTranslationStart.bind(this)}
+              translationUpdateCallback={this.imageTranslationUpdate.bind(this)}
+              translationEndCallback={this.imageTranslationEnd.bind(this)}
+              matrixId={m}
+              imageId={`image${m}-${i}`}
+              imageSelectedStyle={this.props.imageSelectedStyle}
+              panningLeftPadding={this.props.panningLeftPadding}
+              panningRightPadding={this.props.panningRightPadding}
+              panningTopPadding={this.props.panningTopPadding}
+              panningBottomPadding={this.props.panningBottomPadding}
+              scaleAmplifier={this.props.scaleAmplifier}
+              retainScaleOnSwap={retainScaleOnSwap}
+              longPressDelay={longPressDelay}
+              onEditButtonPress={() => this.props.onEditButtonPress(m, i)}
+              isEditButtonVisible={this.props.isEditButtonVisible}
+              EditButtonComponent={this.props.EditButtonComponent}
+              editButtonPosition={this.props.editButtonPosition}
+              matrix={matrix}
+              direction={direction}
+              longPressSensitivity={longPressSensitivity}
+              collageOffsetX={collageOffsetX}
+              collageOffsetY={collageOffsetY}
             />
-        );
-      });
+          );
+        });
 
       return (
-          <View
-              key={m}
-              ref={`matrix${m}`}
-              style={{ flex: 1, flexDirection: sectionDirection }}>
-            { images }
-          </View>
+        <View
+          key={m}
+          ref={`matrix${m}`}
+          style={{ flex: 1, flexDirection: sectionDirection }}
+        >
+          {images}
+        </View>
       );
     });
   }
@@ -76,29 +91,34 @@ class DynamicCollage extends React.Component {
     const { images, collageWidth, collageHeight } = this.state;
 
     // CHECK IF MATRIX = NUMBER OF PHOTOS
-    if(matrix.reduce((a, b) => a + b, 0) !== images.length){
-      throw new Error('Number of images must be equal to sum of matrix. E.g. Matrix = [ 1, 2 ] = 3. Images.length = 3 ');
+    if (matrix.reduce((a, b) => a + b, 0) !== images.length) {
+      throw new Error(
+        "Number of images must be equal to sum of matrix. E.g. Matrix = [ 1, 2 ] = 3. Images.length = 3 "
+      );
     }
 
     return (
-        <View style={[ { width, height }, containerStyle ]} onLayout={(event) => {
+      <View
+        style={[{ width, height }, containerStyle]}
+        onLayout={(event) => {
           this.setState({
             collageWidth: event.nativeEvent.layout.width,
             collageHeight: event.nativeEvent.layout.height,
-            collageOffsetX:  event.nativeEvent.layout.x,
-            collageOffsetY:  event.nativeEvent.layout.y
-          })
-        }}>
-          <View style={{ flex: 1, flexDirection: direction }}>
-            {
-              (collageWidth !== null && collageHeight !== null) ? this.renderMatrix() : null
-            }
-          </View>
+            collageOffsetX: event.nativeEvent.layout.x,
+            collageOffsetY: event.nativeEvent.layout.y,
+          });
+        }}
+      >
+        <View style={{ flex: 1, flexDirection: direction }}>
+          {collageWidth !== null && collageHeight !== null
+            ? this.renderMatrix()
+            : null}
         </View>
+      </View>
     );
   }
 
-  imageTranslationStart(selectedImage){
+  imageTranslationStart(selectedImage) {
     const { matrix } = this.props;
     const { images } = this.state;
     const { matrixId, imageId } = selectedImage.props;
@@ -113,37 +133,45 @@ class DynamicCollage extends React.Component {
 
       // Reset the zIndex of all the images
       images.slice(startIndex, startIndex + element).map((image, i) => {
-        this.refs[`image${m}-${i}`].refs['imageContainer'].setNativeProps({ zIndex: 1 });
+        this.refs[`image${m}-${i}`].refs["imageContainer"].setNativeProps({
+          zIndex: 1,
+        });
       });
     });
 
     // Update the zIndex of the matrix which contains the selected image
     this.refs[`matrix${matrixId}`].setNativeProps({ zIndex: 999 });
     // Update the zIndex of the selected image
-    this.refs[imageId].refs['imageContainer'].setNativeProps({ zIndex: 999 });
+    this.refs[imageId].refs["imageContainer"].setNativeProps({ zIndex: 999 });
   }
 
-  imageTranslationUpdate(selectedImage){
+  imageTranslationUpdate(selectedImage) {
     const targetImageId = this.isImageInBoundaries(selectedImage);
 
-    if(typeof targetImageId === 'string'){
+    if (typeof targetImageId === "string") {
       // IMAGE IS IN BOUNDARIES - HIGHLIGHT POTENTIAL SWAP
       // USE DIRECT MANIPULATION TO AVOID RE-RENDERING ALL IMAGES
-      this.refs[targetImageId].refs['imageContainer'].setNativeProps({ style: this.props.imageSwapStyle });
+      this.refs[targetImageId].refs["imageContainer"].setNativeProps({
+        style: this.props.imageSwapStyle,
+      });
     }
   }
 
-  imageTranslationEnd(selectedImage){
+  imageTranslationEnd(selectedImage) {
     const { images } = this.state;
     const targetImageId = this.isImageInBoundaries(selectedImage);
 
-    if(typeof targetImageId === 'string'){
+    if (typeof targetImageId === "string") {
       // SWAP IMAGES
       const targetImage = this.refs[targetImageId];
 
       const reorderedImages = images.slice();
-      const index1 = images.findIndex((image) => this.imageFindIndex(image, selectedImage));
-      const index2 = images.findIndex((image) => this.imageFindIndex(image, targetImage));
+      const index1 = images.findIndex((image) =>
+        this.imageFindIndex(image, selectedImage)
+      );
+      const index2 = images.findIndex((image) =>
+        this.imageFindIndex(image, targetImage)
+      );
 
       // Swap the images by index
       reorderedImages[index1] = images[index2];
@@ -158,11 +186,16 @@ class DynamicCollage extends React.Component {
     }
   }
 
-  isImageInBoundaries(selectedImage){
+  isImageInBoundaries(selectedImage) {
     const { matrix, separatorStyle } = this.props;
     const { images } = this.state;
     const { translateX, translateY } = selectedImage.state;
-    const { lx, ly, relativeContainerWidth, relativeContainerHeight } = selectedImage.props.boundaries;
+    const {
+      lx,
+      ly,
+      relativeContainerWidth,
+      relativeContainerHeight,
+    } = selectedImage.props.boundaries;
 
     let targetImageId = null;
 
@@ -173,20 +206,24 @@ class DynamicCollage extends React.Component {
 
       images.slice(startIndex, startIndex + element).map((image, i) => {
         // RESET STYLES
-        this.refs[`image${m}-${i}`].refs['imageContainer'].setNativeProps({
-          style: { ...this.props.imageResetStyle, ...separatorStyle }
+        this.refs[`image${m}-${i}`].refs["imageContainer"].setNativeProps({
+          style: { ...this.props.imageResetStyle, ...separatorStyle },
         });
 
         // IS IMAGE NOT THE SELECTED IMAGE (DON'T COMPARE OWN BOUNDARIES)
-        if(selectedImage.props.imageId !== `image${m}-${i}`){
+        if (selectedImage.props.imageId !== `image${m}-${i}`) {
           const targetBoundaries = this.getImageBoundaries(m, i);
 
-          const imagePositionX = (lx + relativeContainerWidth / 2) - translateX;
-          const imagePositionY = (ly + relativeContainerHeight / 2) - translateY;
+          const imagePositionX = lx + relativeContainerWidth / 2 - translateX;
+          const imagePositionY = ly + relativeContainerHeight / 2 - translateY;
 
           // IS IMAGE IN BOUNDARIES?
-          if(imagePositionX > (targetBoundaries.lx) && imagePositionX < (targetBoundaries.ux) &&
-              imagePositionY > (targetBoundaries.ly) && imagePositionY < (targetBoundaries.uy)){
+          if (
+            imagePositionX > targetBoundaries.lx &&
+            imagePositionX < targetBoundaries.ux &&
+            imagePositionY > targetBoundaries.ly &&
+            imagePositionY < targetBoundaries.uy
+          ) {
             targetImageId = `image${m}-${i}`;
           }
         }
@@ -204,11 +241,12 @@ class DynamicCollage extends React.Component {
    *
    * @return int
    */
-  imageFindIndex(image, targetImage){
-
+  imageFindIndex(image, targetImage) {
     // We need to resolve the image to get the URI, if we want to support require();
     const targetImageURI = targetImage.props.source.uri;
-    const imageResolved = Number.isInteger(image) ? Image.resolveAssetSource(image).uri : image;
+    const imageResolved = Number.isInteger(image)
+      ? Image.resolveAssetSource(image).uri
+      : image;
 
     return imageResolved === targetImageURI;
   }
@@ -220,20 +258,33 @@ class DynamicCollage extends React.Component {
    * @param i {number} - images index
    * @return {object}
    */
-  getImageBoundaries(m, i){
+  getImageBoundaries(m, i) {
     const { matrix, direction } = this.props;
     const { collageWidth, collageHeight } = this.state;
 
-    const relativeContainerWidth = (direction === 'row') ? collageWidth / matrix.length : collageWidth / matrix[m];
-    const relativeContainerHeight = (direction === 'row') ? collageHeight / matrix[m] : collageHeight / matrix.length;
+    const relativeContainerWidth =
+      direction === "row"
+        ? collageWidth / matrix.length
+        : collageWidth / matrix[m];
+    const relativeContainerHeight =
+      direction === "row"
+        ? collageHeight / matrix[m]
+        : collageHeight / matrix.length;
 
-    const boundries = (direction === 'row') ? {
-      lx: relativeContainerWidth * (m), ly: relativeContainerHeight * (i),
-      ux: relativeContainerWidth * (m + 1), uy: relativeContainerHeight * (i + 1),
-    } : {
-      lx: relativeContainerWidth * (i), ly: relativeContainerHeight * (m),
-      ux: relativeContainerWidth * (i + 1), uy: relativeContainerHeight * (m + 1),
-    };
+    const boundries =
+      direction === "row"
+        ? {
+            lx: relativeContainerWidth * m,
+            ly: relativeContainerHeight * i,
+            ux: relativeContainerWidth * (m + 1),
+            uy: relativeContainerHeight * (i + 1),
+          }
+        : {
+            lx: relativeContainerWidth * i,
+            ly: relativeContainerHeight * m,
+            ux: relativeContainerWidth * (i + 1),
+            uy: relativeContainerHeight * (m + 1),
+          };
 
     return { ...boundries, relativeContainerWidth, relativeContainerHeight };
   }
@@ -241,7 +292,7 @@ class DynamicCollage extends React.Component {
 
 DynamicCollage.defaultProps = {
   // VARIABLES --------------
-  direction: 'row', // DIRECTION OF THE COLLAGE
+  direction: "row", // DIRECTION OF THE COLLAGE
   panningLeftPadding: 15, // LEFT PANNING PADDING
   panningRightPadding: 15, // RIGHT PANNING PADDING
   panningTopPadding: 15, // TOP PANNING PADDING
@@ -254,15 +305,15 @@ DynamicCollage.defaultProps = {
   // STYLE --------------
   containerStyle: {
     borderWidth: 4,
-    borderColor: 'black',
-    backgroundColor: 'white',
+    borderColor: "black",
+    backgroundColor: "white",
   },
   imageStyle: {}, // DEFAULT IMAGE STYLE
 
   // STYLE OF SEPARATORS ON THE COLLAGE
   separatorStyle: {
     borderWidth: 2,
-    borderColor: 'white',
+    borderColor: "white",
   },
 
   // IMAGE SELECTED
@@ -272,18 +323,18 @@ DynamicCollage.defaultProps = {
 
   // IMAGE SWAP
   imageSwapStyle: {
-    borderColor: '#EB4A4A',
+    borderColor: "#EB4A4A",
     borderWidth: 4,
   },
   imageSwapStyleReset: {
     borderWidth: 0,
-  } // RESET ANY STYLE APPLIED WITH imageSwapStyle
+  }, // RESET ANY STYLE APPLIED WITH imageSwapStyle
 };
 
 DynamicCollage.propTypes = {
   images: PropTypes.array,
   matrix: PropTypes.array,
-  direction: PropTypes.oneOf(['row', 'column']),
+  direction: PropTypes.oneOf(["row", "column"]),
   panningLeftPadding: PropTypes.number, // LEFT PANNING PADDING
   panningRightPadding: PropTypes.number, // RIGHT PANNING PADDING
   panningTopPadding: PropTypes.number, // TOP PANNING PADDING
@@ -292,6 +343,10 @@ DynamicCollage.propTypes = {
   retainScaleOnSwap: PropTypes.bool,
   longPressDelay: PropTypes.number,
   longPressSensitivity: PropTypes.number, // 1 - 20 - How sensitive is the long press?
+  onEditButtonPress: PropTypes.func,
+  EditButtonComponent: PropTypes.func,
+  editButtonPosition: PropTypes.string,
+  isEditButtonVisible: PropTypes.bool,
 };
 
 export { DynamicCollage };


### PR DESCRIPTION
I added four new props in the library in **CollageImage.js** and **DynamicCollage.js**. This functionality is available only for Dynamic Colleges as StaticCollage doesn't need it. The four new props is: 

**- onEditButtonPress: PropTypes.func
- EditButtonComponent: PropTypes.func
- editButtonPosition: PropTypes.string
- isEditButtonVisible: PropTypes.bool**

**onEditButtonPress** has a special return statement and it returns matrix used in the collage and index of the picture to be replaced. **onEditButtonPress={(matrix, index) => {}}** I am attaching the code for onEditButtonPress if anyone will face difficulty to update the state of image in the list. 

```
onEditButtonPress={(m, i) => {
            ImagePicker.openPicker({
              multiple: false,
              mediaType: "photo",
            }).then((rep: any) => {
              if (rep.path && rep.path != "") {
                let list = [...images]
                let t = LayoutData[images.length][index].matrix.filter(
                  (v, index, self) => index < m,
                )
                let s = 0
                if (t.length > 0) {
                  s = t.reduce((a, b) => a + b)
                }
                list[s + i] = rep.path // new list of images with replaced respective image
                this.setSate({ images: list })  
                      // update the state of your images data with new list using class based components
                   
                //  OR
                
                setImages(list) // update the state of your images data with new list using hooks
              }
            })
          }
```

**EditButtonComponent** here you can add your custom component or image or icon or anything you want to be displayed on the image. You can style your component as you like. But don't use Button or TouchableOpacity or something like that which have onPress Prop.

**editButtonPosition** this prop is used to set the alignment of EditButtonComponent. I provided the custom styles for this purpose:  **top-left | top-right | bottom-left | bottom-right**.  **This prop is mandatory.**

**isEditButtonVisible** in case you don't want to use replace image functionality set it to **false**. OR If user wants to save his collage image via ViewShot library then you can firstly you can set it to true then when viewshot has been taken change its state to false. So that this button doesn't captured with the collage.


If you want to update anything in this PR. Let me know and i will update it accordingly.
Thanks.

