### PR TITLE
Adding image onFocus and allowing image container style props for DynamicCollage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .idea/
 .DS_Store
 ./src/.DS_Store
+.watchmanconfig

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ collageRef.current.replaceImage("https://picsum.photos/200", m, i);
 | imageSwapStyleReset  | object   | Yes      | style    | The reverse of imageSwapStyle to reset style after swap. Vital for direct manipulation.                                   |
 | separatorStyle       | object   | Yes      | style    | Style applied to image container. Use border width to create margin between images.                                       |
 | containerStyle       | object   | Yes      | style    | Style applied to the container of the collage. Collage border can be applied here.                                        |
-| imageContainerStyle  | object  | Yes      | style   | Style applied to the image container of the collage.                                    |
-| imageFocussedStyle   | object  | Yes      | style   | Style applied to the focused image container of the collage.                            |
+| imageContainerStyle  | object   | Yes      | style    | Style applied to the image container of the collage.                                                                      |
+| imageFocussedStyle   | object   | Yes      | style    | Style applied to the focused image container of the collage.                                                              |
 
 ## Showcase
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ collageRef.current.replaceImage("https://picsum.photos/200", m, i);
 | separatorStyle       | object   | Yes      | style    | Style applied to image container. Use border width to create margin between images.                                       |
 | containerStyle       | object   | Yes      | style    | Style applied to the container of the collage. Collage border can be applied here.                                        |
 | imageContainerStyle  | object   | Yes      | style    | Style applied to the image container of the collage.                                                                      |
-| imageFocussedStyle   | object   | Yes      | style    | Style applied to the focused image container of the collage.                                                              |
+| imageFocussedStyle   | object   | Yes      | style    | Style applied to the focused image container.                                                              |
 
 ## Showcase
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ collageRef.current.replaceImage("https://picsum.photos/200", m, i);
 | imageSwapStyleReset  | object   | Yes      | style    | The reverse of imageSwapStyle to reset style after swap. Vital for direct manipulation.                                   |
 | separatorStyle       | object   | Yes      | style    | Style applied to image container. Use border width to create margin between images.                                       |
 | containerStyle       | object   | Yes      | style    | Style applied to the container of the collage. Collage border can be applied here.                                        |
-| imageContainerStyle  | object   | Yes      | style    | Style applied to the image container of the collage.                                                                      |
+| imageContainerStyle  | object   | Yes      | style    | Style applied to each image container.                                                                      |
 | imageFocussedStyle   | object   | Yes      | style    | Style applied to the focused image container.                                                              |
 
 ## Showcase

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ collageRef.current.replaceImage("https://picsum.photos/200", m, i);
 | imageSwapStyleReset  | object   | Yes      | style    | The reverse of imageSwapStyle to reset style after swap. Vital for direct manipulation.                                   |
 | separatorStyle       | object   | Yes      | style    | Style applied to image container. Use border width to create margin between images.                                       |
 | containerStyle       | object   | Yes      | style    | Style applied to the container of the collage. Collage border can be applied here.                                        |
+| imageContainerStyle  | object  | Yes      | style   | Style applied to the image container of the collage.                                    |
+| imageFocussedStyle   | object  | Yes      | style   | Style applied to the focused image container of the collage.                            |
 
 ## Showcase
 

--- a/src/CollageImage.js
+++ b/src/CollageImage.js
@@ -72,9 +72,10 @@ class CollageImage extends React.Component {
 
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponder: (evt, gestureState) => true,
-      onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
       onMoveShouldSetPanResponder: (evt, gestureState) => true,
-      onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
+      onMoveShouldSetPanResponderCapture: (evt, gestureState) => {
+        return Math.abs(gestureState.dx) > 5;
+      },
       onPanResponderGrant: (e, gestureState) => {
         this.onLongPressTimeout = setTimeout(() => {
           this.setState({ selected: true }, () => {
@@ -532,7 +533,14 @@ class CollageImage extends React.Component {
   }
 
   render() {
-    const { source, style, imageSelectedStyle } = this.props;
+    const {
+      source,
+      style,
+      imageSelectedStyle,
+      imageFocusId,
+      imageFocussedStyle,
+      imageContainerStyle,
+    } = this.props;
     const {
       panningX,
       panningY,
@@ -550,13 +558,18 @@ class CollageImage extends React.Component {
     return (
       <View
         ref={"imageContainer"}
-        style={{
-          flex: 1,
-          overflow: "hidden",
-          transform: [{ translateX: -translateX }, { translateY: -translateY }],
-          borderWidth: 2,
-          borderColor: "white",
-        }}
+        style={[
+          {
+            flex: 1,
+            overflow: "hidden",
+            transform: [
+              { translateX: -translateX },
+              { translateY: -translateY },
+            ],
+          },
+          imageContainerStyle,
+          imageFocusId === this.id ? imageFocussedStyle : null,
+        ]}
       >
         <View
           style={{
@@ -567,16 +580,18 @@ class CollageImage extends React.Component {
           }}
           {...this._panResponder.panHandlers}
         >
-          <Animated.Image
-            ref={"image"}
-            source={source}
-            style={[
-              style,
-              { right, bottom, width, height },
-              selected ? imageSelectedStyle : null,
-            ]}
-            resizeMode="cover"
-          />
+          <TouchableWithoutFeedback onPress={this.props.onImageFocus}>
+            <Animated.Image
+              ref={"image"}
+              source={source}
+              style={[
+                style,
+                { right, bottom, width, height },
+                selected ? imageSelectedStyle : null,
+              ]}
+              resizeMode="cover"
+            />
+          </TouchableWithoutFeedback>
         </View>
         {this.props.isEditButtonVisible && (
           <TouchableOpacity
@@ -635,6 +650,10 @@ CollageImage.propTypes = {
   ]),
   isEditButtonVisible: PropTypes.bool,
   editButtonIndent: PropTypes.number,
+  imageContainerStyle: PropTypes.object,
+  imageFocussedStyle: PropTypes.object,
+  imageFocusId: PropTypes.string,
+  onImageFocus: PropTypes.func,
 };
 
 export default CollageImage;

--- a/src/CollageImage.js
+++ b/src/CollageImage.js
@@ -73,9 +73,8 @@ class CollageImage extends React.Component {
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponder: (evt, gestureState) => true,
       onMoveShouldSetPanResponder: (evt, gestureState) => true,
-      onMoveShouldSetPanResponderCapture: (evt, gestureState) => {
-        return Math.abs(gestureState.dx) > 5;
-      },
+      onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
+      onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
       onPanResponderGrant: (e, gestureState) => {
         this.onLongPressTimeout = setTimeout(() => {
           this.setState({ selected: true }, () => {
@@ -275,6 +274,11 @@ class CollageImage extends React.Component {
         }
       },
       onPanResponderEnd: (e, gestureState) => {
+        // Focusses the image, if user just taps it, and there is no movement or holding
+        if (Math.abs(gestureState.dx) < 5 && !this.state.selected) {
+          if (this.props.onImageFocus) this.props.onImageFocus(e);
+        }
+
         // Disable scaling, and panning
         this.panning = false;
         this.scaling = false;
@@ -580,18 +584,16 @@ class CollageImage extends React.Component {
           }}
           {...this._panResponder.panHandlers}
         >
-          <TouchableWithoutFeedback onPress={this.props.onImageFocus}>
-            <Animated.Image
-              ref={"image"}
-              source={source}
-              style={[
-                style,
-                { right, bottom, width, height },
-                selected ? imageSelectedStyle : null,
-              ]}
-              resizeMode="cover"
-            />
-          </TouchableWithoutFeedback>
+          <Animated.Image
+            ref={"image"}
+            source={source}
+            style={[
+              style,
+              { right, bottom, width, height },
+              selected ? imageSelectedStyle : null,
+            ]}
+            resizeMode="cover"
+          />
         </View>
         {this.props.isEditButtonVisible && (
           <TouchableOpacity

--- a/src/DynamicCollage.js
+++ b/src/DynamicCollage.js
@@ -343,12 +343,12 @@ class DynamicCollage extends React.Component {
   }
 
   setImageFocusId(m, i) {
-    return function () {
+    return function (e) {
       const imageId = `image${m}-${i}`;
       this.setState((prevState) => ({
         imageFocusId: prevState.imageFocusId === imageId ? null : imageId,
       }));
-      this.props.onImageFocus(m, i);
+      this.props.onImageFocus && this.props.onImageFocus({ e, m, i });
     }.bind(this);
   }
 }
@@ -414,6 +414,7 @@ DynamicCollage.propTypes = {
   retainScaleOnSwap: PropTypes.bool,
   longPressDelay: PropTypes.number,
   longPressSensitivity: PropTypes.number, // 1 - 20 - How sensitive is the long press?
+  onImageFocus: PropTypes.func,
 };
 
 export { DynamicCollage };

--- a/src/DynamicCollage.js
+++ b/src/DynamicCollage.js
@@ -9,6 +9,7 @@ class DynamicCollage extends React.Component {
     super(props);
 
     this.state = {
+      imageFocusId: "",
       images: props.images,
       collageWidth: null,
       collageHeight: null,
@@ -25,7 +26,7 @@ class DynamicCollage extends React.Component {
       longPressDelay,
       longPressSensitivity,
     } = this.props;
-    const { collageOffsetX, collageOffsetY } = this.state;
+    const { collageOffsetX, collageOffsetY, imageFocusId } = this.state;
 
     const sectionDirection = direction === "row" ? "column" : "row";
     const reducer = (accumulator, currentValue) => accumulator + currentValue;
@@ -71,6 +72,10 @@ class DynamicCollage extends React.Component {
               longPressSensitivity={longPressSensitivity}
               collageOffsetX={collageOffsetX}
               collageOffsetY={collageOffsetY}
+              imageFocusId={imageFocusId}
+              imageContainerStyle={this.props.imageContainerStyle}
+              onImageFocus={this.setImageFocusId(m, i)}
+              imageFocussedStyle={this.props.imageFocussedStyle}
             />
           );
         });
@@ -336,6 +341,13 @@ class DynamicCollage extends React.Component {
       }
     );
   }
+
+  setImageFocusId(m, i) {
+    return function () {
+      this.setState({ imageFocusId: `image${m}-${i}` });
+      this.props.onImageFocus(m, i);
+    }.bind(this);
+  }
 }
 
 DynamicCollage.defaultProps = {
@@ -357,6 +369,11 @@ DynamicCollage.defaultProps = {
     backgroundColor: "white",
   },
   imageStyle: {}, // DEFAULT IMAGE STYLE
+  imageContainerStyle: {
+    // DEFAULT IMAGE CONTAINER STYLE
+    borderWidth: 2,
+    borderColor: "white",
+  },
 
   // STYLE OF SEPARATORS ON THE COLLAGE
   separatorStyle: {
@@ -377,6 +394,9 @@ DynamicCollage.defaultProps = {
   imageSwapStyleReset: {
     borderWidth: 0,
   }, // RESET ANY STYLE APPLIED WITH imageSwapStyle
+
+  // IMAGE FOCUS
+  imageFocussedStyle: {},
 };
 
 DynamicCollage.propTypes = {
@@ -391,16 +411,6 @@ DynamicCollage.propTypes = {
   retainScaleOnSwap: PropTypes.bool,
   longPressDelay: PropTypes.number,
   longPressSensitivity: PropTypes.number, // 1 - 20 - How sensitive is the long press?
-  onEditButtonPress: PropTypes.func,
-  EditButtonComponent: PropTypes.func,
-  editButtonPosition: PropTypes.oneOf([
-    "top-left",
-    "top-right",
-    "bottom-left",
-    "bottom-right",
-  ]),
-  isEditButtonVisible: PropTypes.bool,
-  editButtonIndent: PropTypes.number,
 };
 
 export { DynamicCollage };

--- a/src/DynamicCollage.js
+++ b/src/DynamicCollage.js
@@ -75,7 +75,7 @@ class DynamicCollage extends React.Component {
               collageOffsetY={collageOffsetY}
               imageFocusId={imageFocusId}
               imageContainerStyle={this.props.imageContainerStyle}
-              onImageFocus={this.setImageFocusId(m, i)}
+              onImageFocus={(event) => this.setImageFocusId(event, m, i)}
               imageFocussedStyle={this.props.imageFocussedStyle}
             />
           );
@@ -357,14 +357,12 @@ class DynamicCollage extends React.Component {
    * @returns {Indexes} matrix and image indexes
    *
    */
-  setImageFocusId(m, i) {
-    return function (e) {
-      const imageId = `image${m}-${i}`;
-      this.setState((prevState) => ({
-        imageFocusId: prevState.imageFocusId === imageId ? null : imageId,
-      }));
-      this.props.onImageFocus && this.props.onImageFocus(e, { m, i });
-    }.bind(this);
+  setImageFocusId(event, m, i) {
+    const imageId = `image${m}-${i}`;
+    this.setState((prevState) => ({
+      imageFocusId: prevState.imageFocusId === imageId ? null : imageId,
+    }));
+    this.props.onImageFocus && this.props.onImageFocus(event, m, i);
   }
 }
 
@@ -429,6 +427,16 @@ DynamicCollage.propTypes = {
   retainScaleOnSwap: PropTypes.bool,
   longPressDelay: PropTypes.number,
   longPressSensitivity: PropTypes.number, // 1 - 20 - How sensitive is the long press?
+  onEditButtonPress: PropTypes.func,
+  EditButtonComponent: PropTypes.func,
+  editButtonPosition: PropTypes.oneOf([
+    "top-left",
+    "top-right",
+    "bottom-left",
+    "bottom-right",
+  ]),
+  isEditButtonVisible: PropTypes.bool,
+  editButtonIndent: PropTypes.number,
   onImageFocus: PropTypes.func,
   onImagePress: PropTypes.func,
 };

--- a/src/DynamicCollage.js
+++ b/src/DynamicCollage.js
@@ -344,7 +344,10 @@ class DynamicCollage extends React.Component {
 
   setImageFocusId(m, i) {
     return function () {
-      this.setState({ imageFocusId: `image${m}-${i}` });
+      const imageId = `image${m}-${i}`;
+      this.setState((prevState) => ({
+        imageFocusId: prevState.imageFocusId === imageId ? null : imageId,
+      }));
       this.props.onImageFocus(m, i);
     }.bind(this);
   }

--- a/src/DynamicCollage.js
+++ b/src/DynamicCollage.js
@@ -2,6 +2,7 @@ import React from "react";
 import { View, Image, StyleSheet } from "react-native";
 import PropTypes from "prop-types";
 
+import { LayoutData } from "./Layouts";
 import CollageImage from "./CollageImage";
 
 class DynamicCollage extends React.Component {
@@ -342,13 +343,27 @@ class DynamicCollage extends React.Component {
     );
   }
 
+  /**
+   * Function used to focus the image that was just pressed
+   *
+   * @param {number} m - matrix index
+   * @param {number} i - image index
+   *
+   * @typedef {Object} Indexes
+   * @property {number} m - matrix index
+   * @property {number} i - image index
+   *
+   * @return {GestureResponderEvent} e - gesture responder event
+   * @returns {Indexes} matrix and image indexes
+   *
+   */
   setImageFocusId(m, i) {
     return function (e) {
       const imageId = `image${m}-${i}`;
       this.setState((prevState) => ({
         imageFocusId: prevState.imageFocusId === imageId ? null : imageId,
       }));
-      this.props.onImageFocus && this.props.onImageFocus({ e, m, i });
+      this.props.onImageFocus && this.props.onImageFocus(e, { m, i });
     }.bind(this);
   }
 }
@@ -415,6 +430,7 @@ DynamicCollage.propTypes = {
   longPressDelay: PropTypes.number,
   longPressSensitivity: PropTypes.number, // 1 - 20 - How sensitive is the long press?
   onImageFocus: PropTypes.func,
+  onImagePress: PropTypes.func,
 };
 
 export { DynamicCollage };

--- a/src/DynamicCollage.js
+++ b/src/DynamicCollage.js
@@ -10,7 +10,7 @@ class DynamicCollage extends React.Component {
     super(props);
 
     this.state = {
-      imageFocusId: "",
+      imageFocusId: null,
       images: props.images,
       collageWidth: null,
       collageHeight: null,

--- a/src/DynamicCollage.js
+++ b/src/DynamicCollage.js
@@ -184,7 +184,7 @@ class DynamicCollage extends React.Component {
       reorderedImages[index2] = images[index1];
 
       // Set the reordered images as state
-      this.setState({ images: reorderedImages });
+      this.setState({ images: reorderedImages, imageFocusId: null });
 
       // Call the swapped functions on each image
       selectedImage.imageSwapped(targetImage);


### PR DESCRIPTION
Adding `onImageFocus` and `imageFocussedStyle` prop to DynamicCollage. When a user pressed on a image it will trigger the onImafeFocus property exposing two parameters metrixId(m), imageIndex(i) and the event(e) of the TouchableWithoutFeedback. You can add custom style to the focussed image with the prop `imageFocussedStyle`

## API

```
<DynamicCollage
  images={[]}
  onImageFocus={({ e, m, i }) => {
    console.log(m,i)
  }}
  imageFocussedStyle={{ borderColor: "red" }}
  ...
/>
```

